### PR TITLE
ligne 142 : [: -eq : opérateur unaire attendu

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -27,7 +27,7 @@ final_path=$(ynh_app_setting_get $app final_path)
 if [ "$is_public" = "Yes" ]; then
 	ynh_app_setting_set $app is_public 1
 	is_public=1
-elif [ "$is_public" = "No" ]; then
+else
 	ynh_app_setting_set $app is_public 0
 	is_public=0
 fi


### PR DESCRIPTION
I dont really understand why but  `ynh_app_setting_get zerobin is_public` give me an empty result even zerobin was up to date according to commit in official.json.
Relevent console output is : 
```
+ '[' -eq 1 ']'
Attention : ./upgrade: ligne 142 : [: -eq : opérateur unaire attendu
+ systemctl reload nginx
+ ynh_exit_properly
+ exit_code=0
+ '[' 0 -eq 0 ']'
+ exit 0
Succès ! zerobin a été mis à jour
Succès ! La configuration de SSOwat a été générée
Succès ! Mise à jour terminée
```
---
## Problem
- *Description of why you made this PR*

## Solution
- *And how you fix that*

## PR Status
**Work NOT finished**. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [ ] **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- [ ] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/zerobin_ynh%20PR23%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/zerobin_ynh%20PR23%20(Official_fork)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.