### PR TITLE
Fix empty is_public

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -30,6 +30,15 @@ if [ "$is_public" = "Yes" ]; then
 elif [ "$is_public" = "No" ]; then
 	ynh_app_setting_set $app is_public 0
 	is_public=0
+elif [ -z "$is_public" ]; then
+	if grep --quiet "unprotected_uris" "/etc/yunohost/apps/$app/settings.yml"
+	then
+		ynh_app_setting_set $app is_public 1
+		is_public=1
+	else
+		ynh_app_setting_set $app is_public 0
+		is_public=0
+	fi
 fi
 
 # If final_path doesn't exist, create it


### PR DESCRIPTION
## Problem
- *Following https://github.com/YunoHost-Apps/zerobin_ynh/pull/23
The stable version doesn't store the value of is_public. In case of upgrade, the upgrade script can't know is the app is public or not.*

## Solution
- *If is_public is empty, try to find `unprotected_uris` in the config file to know ifg the app is public or not.
Then set and store the value.*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : JimboJoe
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [ ] **Approval (LGTM)** : 
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/zerobin_ynh%20fix_is_public%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/zerobin_ynh%20fix_is_public%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.