### PR TITLE
Allow pastes to be seen in private

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -49,6 +49,10 @@
                     "en": "Is it a public Zerobin site ?",
                     "fr": "Est-ce un site public ?"
                 },
+                "help": {
+                    "en": "If private, only YunoHost users can create a paste, but everyone can read it.",
+                    "fr": "Si privé, seul les utilisateurs YunoHost peuvent créer un paste, mais tout le monde peut lire."
+                },
                 "default": true
             }
         ]

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -76,6 +76,24 @@ then
 fi
 
 #=================================================
+# UPDATE SSOWAT
+#=================================================
+ynh_script_progression --message="Reconfiguring SSOwat..."
+
+if [ $is_public -eq 0 ]
+then
+    # If the app is private, viewing images stays publicly accessible.
+    if [ "$new_path" == "/" ]; then
+        # If the path is /, clear it to prevent any error with the regex.
+        new_path=""
+    fi
+    # Modify the domain to be used in a regex
+    domain_regex=$(echo "$new_domain" | sed 's@-@.@g')
+    ynh_app_setting_set --app=$app --key=protected_regex --value="$domain_regex$new_path/$"
+    ynh_app_setting_set --app=$app --key=unprotected_regex --value="$domain_regex$new_path/.*$"
+fi
+
+#=================================================
 # GENERIC FINALISATION
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -105,8 +105,14 @@ ynh_script_progression --message="Configuring SSOwat..."
 
 # If app is public, add url to SSOWat conf as skipped_uris
 if [ $is_public -eq 1 ]; then
-  # unprotected_uris allows SSO credentials to be passed anyway.
-  ynh_app_setting_set --app=$app --key=unprotected_uris --value="/"
+    # unprotected_uris allows SSO credentials to be passed anyway.
+    ynh_app_setting_set --app=$app --key=unprotected_uris --value="/"
+else
+    # If the app is private, viewing paste stays publicly accessible.
+    # Modify the domain to be used in a regex
+    domain_regex=$(echo "$domain" | sed 's@-@.@g')
+    ynh_app_setting_set --app=$app --key=protected_regex --value="$domain_regex$path_url/$"
+    ynh_app_setting_set --app=$app --key=unprotected_regex --value="$domain_regex$path_url/.*$"
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -142,6 +142,12 @@ ynh_script_progression --message="Upgrading SSOwat configuration..."
 if [ $is_public -eq 1 ]; then
   # unprotected_uris allows SSO credentials to be passed anyway.
   ynh_app_setting_set --app=$app --key=unprotected_uris --value="/"
+else
+    # If the app is private, viewing paste stays publicly accessible.
+    # Modify the domain to be used in a regex
+    domain_regex=$(echo "$domain" | sed 's@-@.@g')
+    ynh_app_setting_set --app=$app --key=protected_regex --value="$domain_regex$path_url/$"
+    ynh_app_setting_set --app=$app --key=unprotected_regex --value="$domain_regex$path_url/.*$"
 fi
 
 #=================================================


### PR DESCRIPTION
## Problem
- *If the app is public, anyone can use it. If private, pastes aren't visible by others.*

## Solution
- *As for other apps, allow in private to see the data but not to create anything.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/zerobin_ynh%20PR32/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/zerobin_ynh%20PR32/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.